### PR TITLE
Update CI to build on ticket branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,8 @@ env:
       - "dependabot/**"
       - "gh-readonly-queue/**"
       - "renovate/**"
-      # - "tickets/**"
-      # - "u/**"
+      - "tickets/**"
+      - "u/**"
   release:
     types: [published]
 
@@ -70,7 +70,6 @@ jobs:
 
     if: >
       github.event_name != 'merge_group'
-      && (startsWith(github.ref, 'refs/heads/main'))
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Remove the clause that makes CI only build on merges to main.