### PR TITLE
SP-2160: Update confluence ingestion to add metadata cleaning and batch ingestion

### DIFF
--- a/notebooks/weaviate_ingest_tutorial.ipynb
+++ b/notebooks/weaviate_ingest_tutorial.ipynb
@@ -35,6 +35,7 @@
    "source": [
     "import os\n",
     "from pathlib import Path\n",
+    "import time\n",
     "\n",
     "import weaviate\n",
     "from dotenv import load_dotenv\n",
@@ -213,11 +214,61 @@
   },
   {
    "cell_type": "markdown",
+   "id": "126729ed",
+   "metadata": {},
+   "source": [
+    "## Clean the Metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3df6629",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sanitize_metadata(docs : list[Document]) -> list[Document]:\n",
+    "    start_time = time.time()\n",
+    "    documents = []\n",
+    "    for doc in docs:\n",
+    "        # Check if page_content is None or not a string, and provide a default\n",
+    "        content = doc.page_content if doc.page_content is not None else \"\"\n",
+    "\n",
+    "        # Clean metadata\n",
+    "        forbidden_keys = {'id', 'vector'}\n",
+    "        if hasattr(doc, 'metadata') and isinstance(doc.metadata, dict):\n",
+    "            cleaned_metadata = {k: v for k, v in doc.metadata.items() if k not in forbidden_keys}\n",
+    "        else:\n",
+    "            cleaned_metadata = {}\n",
+    "\n",
+    "        # Create document with valid string content\n",
+    "        documents.append(Document(page_content=content, metadata=cleaned_metadata))\n",
+    "    end_time = time.time()\n",
+    "    duration = end_time - start_time\n",
+    "    print(f\"Cleaned docs in {duration:.2f} seconds\")\n",
+    "    return documents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84609ffd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test document sanitizer by printing out the first two chunks\n",
+    "cleaned_docs = sanitize_metadata(chunked_docs)\n",
+    "for n in range(2):\n",
+    "    print(cleaned_docs[n])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "90665e20-fc9e-4b64-908c-74d779466e46",
    "metadata": {},
    "source": [
     "## Upload to Weaviate\n",
-    "The last step of ingestion is to upload the documents to Weaviate. For this last step, you must reconnect to Weaviate. It is best to put that connection in a `try:` block, along with your other code. This way you can ensure the client will close even if an Error occurs."
+    "The last step of ingestion is to upload the documents to Weaviate. For this last step, you must reconnect to Weaviate. It is best to put that connection in a `try:` block, along with your other code. This way you can ensure the client will close even if an Error occurs. The first function is fine for small documents (anything that takes less than a minute to scrape), but you will want to use the batched version for any sizeable ingest."
    ]
   },
   {
@@ -228,7 +279,7 @@
    "outputs": [],
    "source": [
     "def push_docs_to_weaviate(\n",
-    "    chunked_docs: list[Document], index_name: str\n",
+    "    docs: list[Document], index_name: str\n",
     ") -> None:\n",
     "    \"\"\"Upload documents to Weaviate using the OpenAI embeddings.\"\"\"\n",
     "    embeddings = OpenAIEmbeddings(\n",
@@ -236,13 +287,50 @@
     "        model=\"text-embedding-3-large\",  # Default model text-embedding-ada-002\n",
     "    )\n",
     "    WeaviateVectorStore.from_documents(\n",
-    "        documents=chunked_docs,\n",
+    "        documents=docs,\n",
     "        embedding=embeddings,\n",
     "        index_name=index_name,\n",
     "        client=client,\n",
     "        text_key=\"page_content\",\n",
-    "        attributes=list(chunked_docs[0].metadata.keys()),\n",
+    "        attributes=list(docs[0].metadata.keys()),\n",
     "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3579449",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def push_docs_to_weaviate_batched(\n",
+    "    docs: list[Document],\n",
+    "    index_name: str,\n",
+    "    batch_size: int = 200\n",
+    ") -> None:\n",
+    "    print(\"Pushing docs to Weaviate in batches\")\n",
+    "    start_time = time.time()\n",
+    "\n",
+    "    embeddings = OpenAIEmbeddings(\n",
+    "        openai_api_key=openai_api_key,\n",
+    "        model=\"text-embedding-ada-002\"\n",
+    "    )\n",
+    "\n",
+    "    for i in range(0, len(docs), batch_size):\n",
+    "        batch = docs[i:i + batch_size]\n",
+    "        print(f\"Batch {i // batch_size + 1}: {len(batch)} docs\")\n",
+    "\n",
+    "        WeaviateVectorStore.from_documents(\n",
+    "            documents=batch,\n",
+    "            embedding=embeddings,\n",
+    "            index_name=index_name,\n",
+    "            client=client,\n",
+    "            text_key=\"page_content\",\n",
+    "            attributes=list(batch[0].metadata.keys()) if batch[0].metadata else [],\n",
+    "        )\n",
+    "\n",
+    "    end_time = time.time()\n",
+    "    print(f\"Pushed all docs to Weaviate in {end_time - start_time:.2f} seconds\")"
    ]
   },
   {
@@ -272,7 +360,7 @@
     "        headers={\"X-OpenAI-Api-Key\": openai_api_key},\n",
     "        skip_init_checks=True,\n",
     "    )\n",
-    "    push_docs_to_weaviate(chunked_docs, \"Full_PDF_Ingestion\")\n",
+    "    push_docs_to_weaviate(cleaned_docs, \"Full_PDF_Ingestion\")\n",
     "    print(client.collections.list_all().keys())\n",
     "except Exception as e:\n",
     "    print(\"Error:\", e)\n",


### PR DESCRIPTION
Add a `sanitize_metadata()` and `push_docs_to_weaviate_batched()` function to the example ingest notebook. I used both of these to fix errors when I ingested Confluence.