### PR TITLE
SP-2164: GitHub scraper: use repo API pagination

### DIFF
--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -39,7 +39,7 @@ if access_token is None:
     raise ValueError("Missing GITHUB_PERSONAL_ACCESS_TOKEN")
 
 
-def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
+def load_files_1repo(repo: str = "lsst/daf_butler") -> list[Document]:
     """Load all utf-8 files from a given GitHub repo.
 
     Parameters

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -93,9 +93,9 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
 
     repos = res.json()
 
-    while 'next' in res.links:
+    while "next" in res.links:
         res = requests.get(
-            res.links['next']['url'],headers={"Authorization": token}
+            res.links["next"]["url"],headers={"Authorization": token}
         )
         repos.extend(res.json())
 

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -98,8 +98,9 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
 
     while "next" in res.links:
         res = requests.get(
-            res.links["next"]["url"], headers={"Authorization": token},
-            timeout=10
+            res.links["next"]["url"],
+            headers={"Authorization": token},
+            timeout=10,
         )
         repos.extend(res.json())
 

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -69,6 +69,36 @@ def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
 
     return docs
 
+def repos_in_org(org_name: str = "lsst-dm") -> list:
+    """Get list of repos with a GitHub organization.
+
+    Parameters
+    ----------
+    org_name : str
+        GitHub organization name
+
+    Returns
+    -------
+    repos : list
+        list of strings, where each string is a repo in the format
+        org_name/repo_name
+    """
+    url = f"https://api.github.com/orgs/{org_name}/repos?simple=yes&per_page=100&page=1"
+    token = str(os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"))
+
+    try:
+        res = requests.get(url,headers={"Authorization": token}, timeout=10)
+    except:
+        logging.exception(f"Failed to retrieve list of repos in org {org_name}.")
+
+    repos = res.json()
+
+    while 'next' in res.links:
+        res = requests.get(res.links['next']['url'],headers={"Authorization": token})
+        repos.extend(res.json())
+
+    repos = [repo["full_name"] for repo in repos]
+    return repos
 
 def load_org(n_repo_max: int = 2, org_name: str = "lsst-dm") -> list:
     """Load all utf-8 files from GitHub repos in a GitHub org.

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -69,6 +69,7 @@ def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
 
     return docs
 
+
 def repos_in_org(org_name: str = "lsst-dm") -> list:
     """Get list of repos with a GitHub organization.
 
@@ -103,6 +104,7 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
 
     repos = [repo["full_name"] for repo in repos]
     return repos
+
 
 def load_org(n_repo_max: int = 2, org_name: str = "lsst-dm") -> list:
     """Load all utf-8 files from GitHub repos in a GitHub org.

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -89,7 +89,7 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
 
     try:
         res = requests.get(url, headers={"Authorization": token}, timeout=10)
-    except:
+    except Exception:
         logging.exception(
             f"Failed to retrieve list of repos in org {org_name}."
         )
@@ -98,12 +98,12 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
 
     while "next" in res.links:
         res = requests.get(
-            res.links["next"]["url"], headers={"Authorization": token}
+            res.links["next"]["url"], headers={"Authorization": token},
+            timeout=10
         )
         repos.extend(res.json())
 
-    repos = [repo["full_name"] for repo in repos]
-    return repos
+    return [repo["full_name"] for repo in repos]
 
 
 def load_org(n_repo_max: int = 2, org_name: str = "lsst-dm") -> list:

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -80,9 +80,10 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
 
     Returns
     -------
-    repos : list
+    list
         list of strings, where each string is a repo in the format
-        org_name/repo_name
+        org_name/repo_name. Returns empty list in the case of a
+        failed GitHub API response.
     """
     url = f"https://api.github.com/orgs/{org_name}/repos?simple=yes&per_page=100&page=1"
     token = str(os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"))
@@ -93,6 +94,7 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
         logging.exception(
             f"Failed to retrieve list of repos in org {org_name}."
         )
+        return []
 
     repos = res.json()
 

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -95,7 +95,7 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
 
     while "next" in res.links:
         res = requests.get(
-            res.links["next"]["url"],headers={"Authorization": token}
+            res.links["next"]["url"], headers={"Authorization": token}
         )
         repos.extend(res.json())
 

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -29,6 +29,12 @@ import requests
 from langchain.schema.document import Document
 from langchain_community.document_loaders import GithubFileLoader
 
+# note that it's necessary to have set the env var
+# GITHUB_PERSONAL_ACCESS_TOKEN to the relevant GitHub API access token
+access_token = os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
+if access_token is None:
+    raise ValueError("Missing GITHUB_PERSONAL_ACCESS_TOKEN")
+
 
 def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
     """Load all utf-8 files from a given GitHub repo.
@@ -43,9 +49,6 @@ def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
     docs : list
         list of langchain documents
     """
-    # note that it's necessary to have set the env var
-    # GITHUB_PERSONAL_ACCESS_TOKEN to the relevant GitHub API access token
-    access_token = str(os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"))
 
     loader = GithubFileLoader(
         repo=repo,
@@ -86,10 +89,9 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
         failed GitHub API response.
     """
     url = f"https://api.github.com/orgs/{org_name}/repos?simple=yes&per_page=100&page=1"
-    token = str(os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"))
 
     try:
-        res = requests.get(url, headers={"Authorization": token}, timeout=10)
+        res = requests.get(url, headers={"Authorization": access_token}, timeout=10)
     except Exception:
         logging.exception(
             f"Failed to retrieve list of repos in org {org_name}."
@@ -101,7 +103,7 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
     while "next" in res.links:
         res = requests.get(
             res.links["next"]["url"],
-            headers={"Authorization": token},
+            headers={"Authorization": access_token},
             timeout=10,
         )
         repos.extend(res.json())

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -87,9 +87,11 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
     token = str(os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"))
 
     try:
-        res = requests.get(url,headers={"Authorization": token}, timeout=10)
+        res = requests.get(url, headers={"Authorization": token}, timeout=10)
     except:
-        logging.exception(f"Failed to retrieve list of repos in org {org_name}.")
+        logging.exception(
+            f"Failed to retrieve list of repos in org {org_name}."
+        )
 
     repos = res.json()
 

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -49,7 +49,6 @@ def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
     docs : list
         list of langchain documents
     """
-
     loader = GithubFileLoader(
         repo=repo,
         branch="main",
@@ -91,7 +90,9 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
     url = f"https://api.github.com/orgs/{org_name}/repos?simple=yes&per_page=100&page=1"
 
     try:
-        res = requests.get(url, headers={"Authorization": access_token}, timeout=10)
+        res = requests.get(
+            url, headers={"Authorization": access_token}, timeout=10
+        )
     except Exception:
         logging.exception(
             f"Failed to retrieve list of repos in org {org_name}."

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -130,7 +130,7 @@ def load_org(n_repo_max: int = 2, org_name: str = "lsst-dm") -> list:
     """
     all_docs: list = []
 
-    repos = repos_in_org(org_name: str = "lsst-dm")
+    repos = repos_in_org(org_name)
 
     for i, repo in enumerate(repos):
         if i >= n_repo_max:

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -53,7 +53,7 @@ def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
         repo=repo,
         branch="main",
         github_api_url="https://api.github.com",
-        access_token=access_token,
+        access_token=str(access_token),
         file_filter=None,
     )
 

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -121,7 +121,9 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
     return [repo["full_name"] for repo in repos]
 
 
-def load_org(org_name: str = "lsst-dm", *, n_repo_max: int | None = None) -> list:
+def load_org(
+    org_name: str = "lsst-dm", *, n_repo_max: int | None = None
+) -> list:
     """Load all utf-8 files from GitHub repos in a GitHub org.
 
     Parameters

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -29,6 +29,9 @@ import requests
 from langchain.schema.document import Document
 from langchain_community.document_loaders import GithubFileLoader
 
+logging.basicConfig(level=logging.INFO)
+_log = logging.getLogger(__name__)
+
 # note that it's necessary to have set the env var
 # GITHUB_PERSONAL_ACCESS_TOKEN to the relevant GitHub API access token
 access_token = os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
@@ -59,7 +62,13 @@ def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
 
     docs: list = []
 
-    for metadata in loader.get_file_paths():
+    try:
+        file_paths = loader.get_file_paths()
+    except Exception:
+        _log.exception("Repo {repo} may not have a branch named 'main'.")
+        return []
+
+    for metadata in file_paths:
         file_path = metadata["path"]
 
         try:
@@ -67,7 +76,7 @@ def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
             doc = Document(string, metadata=metadata)
             docs.append(doc)
         except Exception:
-            logging.exception("Failed to load file.")
+            _log.exception("Failed to load file.")
 
     return docs
 
@@ -94,7 +103,7 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
             url, headers={"Authorization": access_token}, timeout=10
         )
     except Exception:
-        logging.exception(
+        _log.exception(
             f"Failed to retrieve list of repos in org {org_name}."
         )
         return []
@@ -112,31 +121,32 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
     return [repo["full_name"] for repo in repos]
 
 
-def load_org(n_repo_max: int = 2, org_name: str = "lsst-dm") -> list:
+def load_org(org_name: str = "lsst-dm", *, n_repo_max: int | None = None) -> list:
     """Load all utf-8 files from GitHub repos in a GitHub org.
 
     Parameters
     ----------
-    n_repo_max : int
-        number of most recently updated repos for which to ingest
-        contents; should be greater than 0
     org_name : str
         GitHub organization name
+    n_repo_max : int
+        optional. Max number of repos to scrape; should be greater than 0.
+        Default value is None, resulting in scraping all repos within
+        the org.
 
     Returns
     -------
     all_docs : list
         list of langchain documents
     """
-    logging.info(f"Processing GitHub org {org_name}")
+    _log.info(f"Processing GitHub org {org_name}")
     all_docs: list = []
 
     repos = repos_in_org(org_name)
 
     for i, repo in enumerate(repos):
-        if i >= n_repo_max:
+        if (n_repo_max is not None) and (i >= n_repo_max):
             break
-        logging.info(f"Processing GitHub repo {repo}")
+        _log.info(f"Processing GitHub repo {repo}")
         docs = load_files_1repo(repo)
         all_docs = all_docs + docs
 

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -103,9 +103,7 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
             url, headers={"Authorization": access_token}, timeout=10
         )
     except Exception:
-        _log.exception(
-            f"Failed to retrieve list of repos in org {org_name}."
-        )
+        _log.exception(f"Failed to retrieve list of repos in org {org_name}.")
         return []
 
     repos = res.json()

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -81,7 +81,7 @@ def load_files_1repo(repo: str = "lsst/daf_butler") -> list[Document]:
     return docs
 
 
-def repos_in_org(org_name: str = "lsst-dm") -> list:
+def repos_in_org(org_name: str = "lsst-dm") -> list[str]:
     """Get list of repos within a GitHub organization.
 
     Parameters

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -26,7 +26,7 @@ import logging
 import os
 
 import requests
-from langchain.schema.document import Document
+from langchain_core.documents.base import Document
 from langchain_community.document_loaders import GithubFileLoader
 
 logging.basicConfig(level=logging.INFO)
@@ -82,7 +82,7 @@ def load_files_1repo(repo: str = "lsst/daf_butler") -> list:
 
 
 def repos_in_org(org_name: str = "lsst-dm") -> list:
-    """Get list of repos with a GitHub organization.
+    """Get list of repos within a GitHub organization.
 
     Parameters
     ----------

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -26,8 +26,8 @@ import logging
 import os
 
 import requests
-from langchain_core.documents.base import Document
 from langchain_community.document_loaders import GithubFileLoader
+from langchain_core.documents.base import Document
 
 logging.basicConfig(level=logging.INFO)
 _log = logging.getLogger(__name__)

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -94,7 +94,9 @@ def repos_in_org(org_name: str = "lsst-dm") -> list:
     repos = res.json()
 
     while 'next' in res.links:
-        res = requests.get(res.links['next']['url'],headers={"Authorization": token})
+        res = requests.get(
+            res.links['next']['url'],headers={"Authorization": token}
+        )
         repos.extend(res.json())
 
     repos = [repo["full_name"] for repo in repos]

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -128,25 +128,14 @@ def load_org(n_repo_max: int = 2, org_name: str = "lsst-dm") -> list:
     all_docs : list
         list of langchain documents
     """
-    # this will give an output 'list' of repos sorted
-    # from most to least recently updated
-    api_url = (
-        "https://api.github.com/orgs/"
-        + org_name
-        + "/repos?per_page=100&sort=updated"
-    )
-
     all_docs: list = []
 
-    try:
-        result = requests.get(api_url, timeout=10)
-        data = result.json()
-    except Exception:
-        logging.exception("Failed to retrieve list of org's repos.")
-        return all_docs
+    repos = repos_in_org(org_name: str = "lsst-dm")
 
-    for i in range(n_repo_max):
-        docs = load_files_1repo(repo=data[i]["full_name"])
+    for i, repo in enumerate(repos):
+        if i >= n_repo_max:
+            break
+        docs = load_files_1repo(repo)
         all_docs = all_docs + docs
 
     return all_docs

--- a/python/rubin/rag/extra_scripts/scrape_github.py
+++ b/python/rubin/rag/extra_scripts/scrape_github.py
@@ -119,7 +119,7 @@ def load_org(n_repo_max: int = 2, org_name: str = "lsst-dm") -> list:
     ----------
     n_repo_max : int
         number of most recently updated repos for which to ingest
-        contents; should be greater than 0 but less than or equal to 100
+        contents; should be greater than 0
     org_name : str
         GitHub organization name
 
@@ -128,6 +128,7 @@ def load_org(n_repo_max: int = 2, org_name: str = "lsst-dm") -> list:
     all_docs : list
         list of langchain documents
     """
+    logging.info(f"Processing GitHub org {org_name}")
     all_docs: list = []
 
     repos = repos_in_org(org_name)
@@ -135,6 +136,7 @@ def load_org(n_repo_max: int = 2, org_name: str = "lsst-dm") -> list:
     for i, repo in enumerate(repos):
         if i >= n_repo_max:
             break
+        logging.info(f"Processing GitHub repo {repo}")
         docs = load_files_1repo(repo)
         all_docs = all_docs + docs
 


### PR DESCRIPTION
Update GitHub scraper to use pagination of the GitHub repo API in order to be able to scrape > 100 repos per organization. Also roll in other updates to better match other scrapers (handling of API token retrieval, logging conventions).