### PR TITLE
Migrate to text-embedding-3-large

### DIFF
--- a/python/rubin/rag/chatbot.py
+++ b/python/rubin/rag/chatbot.py
@@ -103,7 +103,9 @@ def configure_retriever() -> VectorStoreRetriever:
         client=configure_client(),
         index_name="LangChain_9787ec4b92d3438a8de3ff04ead7ead6",
         text_key="page_content",
-        embedding=OpenAIEmbeddings(model="text-embedding-3", dimensions=1536),
+        embedding=OpenAIEmbeddings(
+            model="text-embedding-3-large", dimensions=1536
+        ),
         attributes=["source", "source_key"],  # Metadata to fetch
     ).as_retriever(
         search_type="similarity",

--- a/python/rubin/rag/chatbot.py
+++ b/python/rubin/rag/chatbot.py
@@ -103,7 +103,7 @@ def configure_retriever() -> VectorStoreRetriever:
         client=configure_client(),
         index_name="LangChain_9787ec4b92d3438a8de3ff04ead7ead6",
         text_key="page_content",
-        embedding=OpenAIEmbeddings(),
+        embedding=OpenAIEmbeddings(model="text-embedding-3", dimensions=1536),
         attributes=["source", "source_key"],  # Metadata to fetch
     ).as_retriever(
         search_type="similarity",


### PR DESCRIPTION
Change the embedding model used by the vectorstore/retriever to text-embedding-3, with customizable dimensions (3072 for large, using 1536)